### PR TITLE
addition: `PropertyValue` constraint

### DIFF
--- a/src/PHPUnit/Constraint/Objects/PropertyValue.php
+++ b/src/PHPUnit/Constraint/Objects/PropertyValue.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Craftzing\TestBench\PHPUnit\Constraint\Objects;
+
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use Override;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\ExpectationFailedException;
+use ReflectionClass;
+
+use function is_object;
+
+final class PropertyValue extends Constraint
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly Constraint $constraint,
+    ) {}
+
+    #[Override]
+    protected function matches(mixed $other): bool
+    {
+        is_object($other) or throw new InvalidArgumentException(self::class . ' can only be evaluated for objects.');
+
+        $actualObject = new ReflectionClass($other);
+
+        if ($actualObject->hasProperty($this->name) === false) {
+            return false;
+        }
+
+        $actualPropertyValue = $actualObject->getProperty($this->name)->getValue($other);
+
+        try {
+            Assert::assertThat($actualPropertyValue, $this->constraint);
+        } catch (ExpectationFailedException) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function toString(): string
+    {
+        $comparesTo = Str::of($this->constraint::class)
+            ->classBasename()
+            ->snake(' ');
+
+        return "`$this->name` property value $comparesTo";
+    }
+}

--- a/src/PHPUnit/Constraint/Objects/PropertyValueTest.php
+++ b/src/PHPUnit/Constraint/Objects/PropertyValueTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Craftzing\TestBench\PHPUnit\Constraint\Objects;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\Constraint\Callback;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Constraint\IsEqual;
+use PHPUnit\Framework\Constraint\IsIdentical;
+use PHPUnit\Framework\Constraint\IsTrue;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class PropertyValueTest extends TestCase
+{
+    #[Test]
+    #[TestWith([new IsEqual('someValue'), 'is equal'])]
+    #[TestWith([new IsIdentical('someValue'), 'is identical'])]
+    public function itCanConstruct(Constraint $constraint, string $toString): void
+    {
+        $name = 'propertyName';
+
+        $instance = new PropertyValue($name, $constraint);
+
+        $this->assertSame($name, $instance->name);
+        $this->assertSame($constraint, $instance->constraint);
+        $this->assertStringContainsString($toString, $instance->toString());
+    }
+
+    #[Test]
+    #[TestWith([true], 'Boolean')]
+    #[TestWith([1], 'Integers')]
+    #[TestWith([['event']], 'Array')]
+    public function itFailsWhenEvaluatingNonObjects(mixed $value): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('can only be evaluated for objects.');
+
+        $this->assertThat($value, new PropertyValue('propertyName', new IsTrue()));
+    }
+
+    #[Test]
+    public function itFailsWhenPropertiesDontExist(): void
+    {
+        $object = new stdClass();
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $this->assertThat($object, new PropertyValue('propertyName', new IsTrue()));
+    }
+
+    #[Test]
+    public function itFailsWhenPropertiesDontMatchGivenConstraints(): void
+    {
+        $constraint = new Callback(fn (): bool => false);
+        $object = $this->objectWithIdProperty();
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $this->assertThat($object, new PropertyValue('id', $constraint));
+    }
+
+    #[Test]
+    public function itPassesWhenPropertiesMatchGivenConstraints(): void
+    {
+        $constraint = new Callback(fn (): bool => true);
+        $object = $this->objectWithIdProperty();
+
+        $this->assertThat($object, new PropertyValue('id', $constraint));
+    }
+
+    /**
+     * @return object{id: string}
+     */
+    private function objectWithIdProperty(): object
+    {
+        return new class
+        {
+            public function __construct(
+                public string $id = 'SomeId',
+            ) {}
+        };
+    }
+}


### PR DESCRIPTION
This constraint allows us to perform assertions on object properties using existing constraints. E.g:
```php
$this->assertThat($object, new PropertyValue('id', new IsIdentical('SomeId'));
```