### PR TITLE
change: Derive event constraints from instances in `WasDispatched` event constraint

### DIFF
--- a/src/Laravel/Constraint/Events/WasDispatched.php
+++ b/src/Laravel/Constraint/Events/WasDispatched.php
@@ -4,77 +4,103 @@ declare(strict_types=1);
 
 namespace Craftzing\TestBench\Laravel\Constraint\Events;
 
-use Closure;
+use Craftzing\TestBench\PHPUnit\Constraint\Objects\DerivesConstraintsFromObjects;
+use Craftzing\TestBench\PHPUnit\Constraint\ProvidesAdditionalFailureDescription;
 use Craftzing\TestBench\PHPUnit\Constraint\Quantable;
 use InvalidArgumentException;
 use Override;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\ExpectationFailedException;
 
 use function array_filter;
 use function count;
 use function gettype;
+use function is_object;
 use function is_string;
 
 final class WasDispatched extends Constraint implements Quantable
 {
     use RequiresEventFake;
+    use DerivesConstraintsFromObjects;
+    use ProvidesAdditionalFailureDescription;
 
     public function __construct(
-        public ?Closure $assertEvent = null,
-        public ?int $times = null,
+        public readonly ?int $times = null,
+        Constraint ...$eventConstraints,
     ) {
         $this->eventFake = $this->resolveEventFake();
+        $this->objectConstraints = $eventConstraints;
     }
 
     public function times(int $count): self
     {
-        return new self($this->assertEvent, $count);
+        return new self($count, ...$this->objectConstraints);
     }
 
     public function never(): self
     {
-        return new self($this->assertEvent, 0);
+        return new self(0, ...$this->objectConstraints);
     }
 
     public function once(): self
     {
-        return new self($this->assertEvent, 1);
+        return new self(1, ...$this->objectConstraints);
+    }
+
+    public function withEventConstraints(Constraint ...$eventConstraints): self
+    {
+        return new self($this->times, ...$eventConstraints);
     }
 
     #[Override]
     protected function matches(mixed $other): bool
     {
-        is_string($other) or throw new InvalidArgumentException(
-            self::class . ' can only be evaluated for strings, got ' . gettype($other) . '.',
-        );
+        $eventName = match (true) {
+            is_string($other) => $other,
+            is_object($other) => $other::class,
+            default => throw new InvalidArgumentException(
+                self::class . ' can only be evaluated for strings or event instances, got ' . gettype($other) . '.',
+            ),
+        };
 
         // Note that we deliberately don't use the EventFake::assertDispatched() method. Going through the dispatched
-        // events ourselves gives us the flexibility to match them against the given event assertions. That way,
-        // we can check if an event was dispatched x times matching the event assertions without having to
-        // provide "escape hatches" in the event assertion callback for non-matching events...
-        $matchingDispatchedEvents = array_filter(
-            $this->eventFake->dispatchedEvents()[$other] ?? [],
-            $this->matchesEventAssertions(...),
+        // events ourselves gives us the flexibility to match them against the given or derived event constraints...
+        $matchingDispatchedEvents = $this->eventFake->dispatchedEvents()[$eventName] ?? [];
+
+        $dispatchedEventsMatchingConstraints = array_filter(
+            $matchingDispatchedEvents,
+            fn (array $dispatchedEvent): bool => $this->matchesEventConstraints(
+                $other,
+                $dispatchedEvent[0],
+                // When the event was dispatched exactly once, we should add all nested expectation failures to the
+                // failure description in order to provide as much context as possible. We should not to this for
+                // events that were dispatched more than once, as that would pollute the failure output...
+                count($matchingDispatchedEvents) === 1,
+            ),
         );
 
         return match ($this->times) {
-            null => $matchingDispatchedEvents !== [],
-            default => count($matchingDispatchedEvents) === $this->times,
+            null => $dispatchedEventsMatchingConstraints !== [],
+            default => count($dispatchedEventsMatchingConstraints) === $this->times,
         };
     }
 
-    /**
-     * @param array{string|object} $dispatchedEvent
-     */
-    private function matchesEventAssertions(array $dispatchedEvent): bool
-    {
-        [$event] = $dispatchedEvent;
+    private function matchesEventConstraints(
+        string|object $expected,
+        string|object $dispatchedEvent,
+        bool $addExpectationFailuresToFailureDescriptions,
+    ): bool {
+        foreach ($this->givenOrDerivedObjectConstraints($expected) as $matchesConstraint) {
+            try {
+                Assert::assertThat($dispatchedEvent, $matchesConstraint);
+            } catch (ExpectationFailedException $expectationFailed) {
+                if ($addExpectationFailuresToFailureDescriptions) {
+                    $this->additionalFailureDescriptions[] = $expectationFailed->getMessage();
+                }
 
-        try {
-            $this->assertEvent?->__invoke($event);
-        } catch (ExpectationFailedException) {
-            return false;
+                return false;
+            }
         }
 
         return true;
@@ -82,15 +108,22 @@ final class WasDispatched extends Constraint implements Quantable
 
     public function toString(): string
     {
-        $message = 'event was dispatched';
+        return 'event was dispatched';
+    }
+
+    protected function failureDescription(mixed $other): string
+    {
+        $message = parent::failureDescription($other);
 
         if ($this->times !== null) {
-            $message .= " $this->times times";
+            $message .= " $this->times time(s)";
         }
 
-        if ($this->assertEvent !== null) {
-            $message .= ' with expected event assertions';
-        }
+        $message .= match (true) {
+            $this->objectConstraints !== [] => ' with given event constraints',
+            $this->givenOrDerivedObjectConstraints($other) !== [] => ' with derived event constraints',
+            default => '',
+        };
 
         return $message;
     }

--- a/src/Laravel/Constraint/Events/WasDispatchedTest.php
+++ b/src/Laravel/Constraint/Events/WasDispatchedTest.php
@@ -5,17 +5,29 @@ declare(strict_types=1);
 namespace Craftzing\TestBench\Laravel\Constraint\Events;
 
 use Craftzing\TestBench\Laravel\Doubles\Events\DummyEvent;
+use Craftzing\TestBench\PHPUnit\Constraint\Objects\DeriveConstraintsFromObjectUsingFakes;
+use Craftzing\TestBench\PHPUnit\Constraint\Objects\DeriveConstraintsFromObjectUsingReflection;
 use Craftzing\TestBench\PHPUnit\DataProviders\QuantableConstraintProvider;
 use Illuminate\Support\Facades\Event;
 use InvalidArgumentException;
 use LogicException;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\Constraint\Callback;
+use PHPUnit\Framework\Constraint\IsIdentical;
 use PHPUnit\Framework\ExpectationFailedException;
 
 final class WasDispatchedTest extends TestCase
 {
+    #[Before]
+    public function resetDeriveConstraintsFromObjectUsing(): void
+    {
+        WasDispatched::deriveConstraintsFromObjectUsing(null);
+    }
+
     #[Test]
     public function itFailsToConstructWhenNotSpying(): void
     {
@@ -26,14 +38,26 @@ final class WasDispatchedTest extends TestCase
     }
 
     #[Test]
-    public function itCanConstructWithEventAssertions(): void
+    public function itCanConstructWithoutArguments(): void
     {
         WasDispatched::spy();
-        $assertEvent = function (): void {};
 
-        $instance = new WasDispatched($assertEvent);
+        $instance = new WasDispatched();
 
-        $this->assertSame($assertEvent, $instance->assertEvent);
+        $this->assertNull($instance->times);
+        $this->assertEmpty($instance->objectConstraints);
+    }
+
+    #[Test]
+    public function itCanConstructWithEventConstraints(): void
+    {
+        WasDispatched::spy();
+        $eventConstraints = [new IsIdentical('event')];
+
+        $instance = new WasDispatched()->withEventConstraints(...$eventConstraints);
+
+        $this->assertNull($instance->times);
+        $this->assertSame($eventConstraints, $instance->objectConstraints);
     }
 
     #[Test]
@@ -41,27 +65,29 @@ final class WasDispatchedTest extends TestCase
     public function itImplementsTheQuantableInterface(QuantableConstraintProvider $quantise): void
     {
         WasDispatched::spy();
-        $assertEvent = function (): void {};
-        $instance = new WasDispatched($assertEvent);
+        $eventConstraints = [new IsIdentical('event')];
+        $instance = new WasDispatched()->withEventConstraints(...$eventConstraints);
 
         $quantisedInstance = $quantise($instance);
 
         $this->assertNull($instance->times);
-        $this->assertSame($assertEvent, $instance->assertEvent);
         $this->assertSame($quantise->times, $quantisedInstance->times);
-        $this->assertSame($assertEvent, $quantisedInstance->assertEvent);
+        $this->assertSame($eventConstraints, $instance->objectConstraints);
+        $this->assertSame($eventConstraints, $quantisedInstance->objectConstraints);
     }
 
     #[Test]
-    public function itCannotEvaluateValuesThatAreNotStrings(): void
+    #[TestWith([true], 'Boolean')]
+    #[TestWith([1], 'Integers')]
+    #[TestWith([['event']], 'Array')]
+    public function itCannotEvaluateUnsupportedValueTypes(mixed $value): void
     {
         WasDispatched::spy();
-        $event = new DummyEvent();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(WasDispatched::class . ' can only be evaluated for strings');
+        $this->expectExceptionMessage(WasDispatched::class . ' can only be evaluated for strings or event instances');
 
-        $this->assertThat($event, new WasDispatched());
+        $this->assertThat($value, new WasDispatched());
     }
 
     #[Test]
@@ -88,49 +114,50 @@ final class WasDispatchedTest extends TestCase
     }
 
     #[Test]
-    public function itFailsWhenNotDispatchedWithExpectedEventAssertions(): void
+    public function itFailsWhenDispatchedButNotWithGivenEventConstraints(): void
     {
         WasDispatched::spy();
-        Event::dispatch(new DummyEvent(1, 2));
+        $event = new DummyEvent('first', 'last');
+        Event::dispatch($event);
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('event was dispatched with expected event assertions.');
+        $this->expectExceptionMessage('event was dispatched with given event constraints.');
 
-        $this->assertThat(DummyEvent::class, new WasDispatched(function (DummyEvent $event): void {
-            $this->assertSame(['first', 'last'], $event->arguments);
-        }));
+        $this->assertThat($event, new WasDispatched()->withEventConstraints(
+            new Callback(fn () => false),
+        ));
     }
 
     #[Test]
-    public function itPassesWhenDispatchedWithExpectedEventAssertions(): void
+    public function itPassesWhenDispatchedWithGivenEventConstraints(): void
     {
         WasDispatched::spy();
-        $arguments = ['first', 'last'];
+        $event = new DummyEvent('first', 'last');
 
-        Event::dispatch(new DummyEvent(...$arguments));
+        Event::dispatch($event);
 
-        $this->assertThat(DummyEvent::class, new WasDispatched(function (DummyEvent $event) use ($arguments): void {
-            $this->assertSame($arguments, $event->arguments);
-        }));
+        $this->assertThat($event, new WasDispatched()->withEventConstraints(
+            new Callback(fn () => true),
+        ));
     }
 
     #[Test]
     #[DataProviderExternal(QuantableConstraintProvider::class, 'tooFewOrTooManyTimes')]
-    public function itFailsWhenNotDispatchedExpectedTimes(QuantableConstraintProvider $quantise): void
+    public function itFailsWhenDispatchedButNotGivenTimes(QuantableConstraintProvider $quantise): void
     {
         WasDispatched::spy();
         $event = 'some.event';
         $quantise->applyTo(fn () => Event::dispatch($event));
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage("event was dispatched $quantise->expected times.");
+        $this->expectExceptionMessage("event was dispatched $quantise->expected time(s).");
 
         $this->assertThat($event, new WasDispatched()->times($quantise->expected));
     }
 
     #[Test]
     #[DataProviderExternal(QuantableConstraintProvider::class, 'cases')]
-    public function itPassesWhenDispatchedExpectedTimes(QuantableConstraintProvider $quantise): void
+    public function itPassesWhenDispatchedGivenTimes(QuantableConstraintProvider $quantise): void
     {
         WasDispatched::spy();
         $event = 'some.event';
@@ -142,35 +169,111 @@ final class WasDispatchedTest extends TestCase
 
     #[Test]
     #[DataProviderExternal(QuantableConstraintProvider::class, 'tooFewOrTooManyTimes')]
-    public function itFailsWhenNotDispatchedExpectedTimesWithExpectedEventAssertions(
+    public function itFailsWhenDispatchedWithGivenEventConstrainsButNotGivenTimes(
         QuantableConstraintProvider $quantise,
     ): void {
         WasDispatched::spy();
-        $arguments = ['first', 'last'];
-        $quantise->applyTo(fn () => Event::dispatch(new DummyEvent(...$arguments)));
+        $event = new DummyEvent('first', 'last');
+        $quantise->applyTo(fn () => Event::dispatch($event));
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage("event was dispatched $quantise->expected times with expected event assertions.");
+        $this->expectExceptionMessage("event was dispatched $quantise->expected time(s)");
 
-        $this->assertThat(DummyEvent::class, new WasDispatched(function (DummyEvent $event) use ($arguments): void {
-            $this->assertSame($arguments, $event->arguments);
-        })->times($quantise->expected));
+        $this->assertThat($event, new WasDispatched()->times($quantise->expected)->withEventConstraints(
+            new Callback(fn () => true),
+        ));
+    }
+
+    #[Test]
+    #[DataProviderExternal(QuantableConstraintProvider::class, 'atLeastOnce')]
+    public function itFailsWhenDispatchedGivenTimesButNotWithGivenEventConstrains(
+        QuantableConstraintProvider $quantise,
+    ): void {
+        WasDispatched::spy();
+        $event = new DummyEvent('first', 'last');
+        $quantise->applyTo(fn () => Event::dispatch($event));
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("event was dispatched $quantise->expected time(s) with given event constraints.");
+
+        $this->assertThat($event, new WasDispatched()->times($quantise->expected)->withEventConstraints(
+            new Callback(fn () => false),
+        ));
     }
 
     #[Test]
     #[DataProviderExternal(QuantableConstraintProvider::class, 'cases')]
-    public function itPassesWhenDispatchedExpectedTimesWithExpectedEventAssertions(
+    public function itPassesWhenDispatchedGivenTimesWithGivenEventConstraints(
         QuantableConstraintProvider $quantise,
     ): void {
         WasDispatched::spy();
-        $arguments = ['first', 'last'];
+        $event = new DummyEvent('first', 'last');
 
-        $quantise->applyTo(fn () => Event::dispatch(new DummyEvent(...$arguments)));
+        $quantise->applyTo(fn () => Event::dispatch($event));
 
-        $this->assertThat(DummyEvent::class, $quantise(new WasDispatched(function (
-            DummyEvent $event,
-        ) use ($arguments): void {
-            $this->assertSame($arguments, $event->arguments);
-        })));
+        $this->assertThat($event, $quantise(new WasDispatched()->withEventConstraints(
+            new Callback(fn () => true),
+        )));
+    }
+
+    #[Test]
+    public function itCannotDeriveEventConstraintsFromEventStrings(): void
+    {
+        WasDispatched::spy();
+
+        $eventConstraints = new WasDispatched()->givenOrDerivedObjectConstraints(DummyEvent::class);
+
+        $this->assertEmpty($eventConstraints);
+    }
+
+    #[Test]
+    public function itCanDeriveEventConstraintsFromEventObjects(): void
+    {
+        WasDispatched::spy();
+        $event = new DummyEvent('actual');
+        $expected = new DeriveConstraintsFromObjectUsingReflection()->__invoke($event);
+
+        $eventConstraints = new WasDispatched()->givenOrDerivedObjectConstraints($event);
+
+        $this->assertEquals($expected, $eventConstraints);
+    }
+
+    #[Test]
+    public function itCanDeriveEventConstraintsFromEventObjectsUsingCustomImplementations(): void
+    {
+        $event = new DummyEvent('actual');
+        $deriveConstraintsFromObject = DeriveConstraintsFromObjectUsingFakes::passingConstraints();
+        WasDispatched::spy();
+        WasDispatched::deriveConstraintsFromObjectUsing($deriveConstraintsFromObject);
+
+        $eventConstraints = new WasDispatched()->givenOrDerivedObjectConstraints($event);
+
+        $this->assertEquals($deriveConstraintsFromObject->constraints, $eventConstraints);
+    }
+
+    #[Test]
+    public function itFailsWhenNotDispatchedWithDerivedEventConstraints(): void
+    {
+        $event = new DummyEvent('actual');
+        WasDispatched::spy();
+        WasDispatched::deriveConstraintsFromObjectUsing(DeriveConstraintsFromObjectUsingFakes::failingConstraints());
+        Event::dispatch($event);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('event was dispatched with derived event constraints.');
+
+        $this->assertThat($event, new WasDispatched());
+    }
+
+    #[Test]
+    public function itPassesWhenDispatchedWithDerivedEventConstraints(): void
+    {
+        $event = new DummyEvent('actual');
+        WasDispatched::spy();
+        WasDispatched::deriveConstraintsFromObjectUsing(DeriveConstraintsFromObjectUsingFakes::passingConstraints());
+
+        Event::dispatch($event);
+
+        $this->assertThat($event, new WasDispatched());
     }
 }

--- a/src/PHPUnit/Constraint/Objects/DeriveConstraintsFromObject.php
+++ b/src/PHPUnit/Constraint/Objects/DeriveConstraintsFromObject.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Craftzing\TestBench\PHPUnit\Constraint\Objects;
+
+use PHPUnit\Framework\Constraint\Constraint;
+
+interface DeriveConstraintsFromObject
+{
+    /**
+     * @return array<Constraint>
+     */
+    public function __invoke(object $object): array;
+}

--- a/src/PHPUnit/Constraint/Objects/DeriveConstraintsFromObjectUsingFakes.php
+++ b/src/PHPUnit/Constraint/Objects/DeriveConstraintsFromObjectUsingFakes.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Craftzing\TestBench\PHPUnit\Constraint\Objects;
+
+use PHPUnit\Framework\Constraint\Callback;
+
+final readonly class DeriveConstraintsFromObjectUsingFakes implements DeriveConstraintsFromObject
+{
+    /**
+     * @param array<\PHPUnit\Framework\Constraint\Constraint> $constraints
+     */
+    public function __construct(
+        public array $constraints,
+    ) {}
+
+    public static function failingConstraints(): self
+    {
+        return new self([
+            new Callback(fn () => false),
+        ]);
+    }
+
+    public static function passingConstraints(): self
+    {
+        return new self([
+            new Callback(fn () => true),
+        ]);
+    }
+
+    public function __invoke(object $object): array
+    {
+        return $this->constraints;
+    }
+}

--- a/src/PHPUnit/Constraint/Objects/DeriveConstraintsFromObjectUsingReflection.php
+++ b/src/PHPUnit/Constraint/Objects/DeriveConstraintsFromObjectUsingReflection.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Craftzing\TestBench\PHPUnit\Constraint\Objects;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Constraint\IsEqual;
+use ReflectionClass;
+use ReflectionProperty;
+
+use function array_map;
+
+final readonly class DeriveConstraintsFromObjectUsingReflection
+{
+    /**
+     * @return array<Constraint>
+     */
+    public function __invoke(object $object): array
+    {
+        return array_map(function (ReflectionProperty $property) use ($object): Constraint {
+            return new PropertyValue($property->name, new IsEqual($property->getValue($object)));
+        }, new ReflectionClass($object)->getProperties(ReflectionProperty::IS_PUBLIC));
+    }
+}

--- a/src/PHPUnit/Constraint/Objects/DeriveConstraintsFromObjectUsingReflectionTest.php
+++ b/src/PHPUnit/Constraint/Objects/DeriveConstraintsFromObjectUsingReflectionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Craftzing\TestBench\PHPUnit\Constraint\Objects;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Constraint\IsEqual;
+use PHPUnit\Framework\TestCase;
+
+final class DeriveConstraintsFromObjectUsingReflectionTest extends TestCase
+{
+    #[Test]
+    public function itShouldNotDeriveConstraintsFromNonPublicProperties(): void
+    {
+        $object = new readonly class
+        {
+            public function __construct(
+                protected mixed $protected = 'protected',
+                protected mixed $private = 'private',
+            ) {}
+        };
+
+        $results = new DeriveConstraintsFromObjectUsingReflection()->__invoke($object);
+
+        $this->assertEmpty($results);
+    }
+
+    #[Test]
+    public function itCanDeriveConstraintsFromPublicProperties(): void
+    {
+        $value = 'SomePublicValue';
+        $object = new readonly class ($value)
+        {
+            public function __construct(
+                public mixed $somePublicProperty,
+            ) {}
+        };
+
+        $results = new DeriveConstraintsFromObjectUsingReflection()->__invoke($object);
+
+        $this->assertEquals([
+            new PropertyValue('somePublicProperty', new IsEqual($value)),
+        ], $results);
+    }
+}

--- a/src/PHPUnit/Constraint/Objects/DerivesConstraintsFromObjects.php
+++ b/src/PHPUnit/Constraint/Objects/DerivesConstraintsFromObjects.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Craftzing\TestBench\PHPUnit\Constraint\Objects;
+
+use PHPUnit\Framework\Constraint\Constraint;
+
+use function is_string;
+
+trait DerivesConstraintsFromObjects
+{
+    private static ?DeriveConstraintsFromObject $deriveConstraintsFromObject = null;
+
+    /**
+     * @var array<Constraint>
+     */
+    public readonly array $objectConstraints;
+
+    /**
+     * @return array<Constraint>
+     */
+    public function givenOrDerivedObjectConstraints(string|object $expected): array
+    {
+        if ($this->objectConstraints !== []) {
+            return $this->objectConstraints;
+        }
+
+        if (is_string($expected)) {
+            return [];
+        }
+
+        return (self::$deriveConstraintsFromObject ?: new DeriveConstraintsFromObjectUsingReflection())($expected);
+    }
+
+    public static function deriveConstraintsFromObjectUsing(
+        ?DeriveConstraintsFromObject $deriveConstraintsFromObject,
+    ): void {
+        self::$deriveConstraintsFromObject = $deriveConstraintsFromObject;
+    }
+}

--- a/src/PHPUnit/Constraint/ProvidesAdditionalFailureDescription.php
+++ b/src/PHPUnit/Constraint/ProvidesAdditionalFailureDescription.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Craftzing\TestBench\PHPUnit\Constraint;
+
+use Illuminate\Support\Collection;
+use Override;
+
+trait ProvidesAdditionalFailureDescription
+{
+    /**
+     * @var array<string>
+     */
+    private array $additionalFailureDescriptions = [];
+
+    #[Override]
+    protected function additionalFailureDescription(mixed $other): string
+    {
+        return new Collection($this->additionalFailureDescriptions)
+            ->map(fn (string $description): string => "\n* $description\n")
+            ->implode('');
+    }
+}


### PR DESCRIPTION
This PR aims to further improve the event constraints by enabling to derive event constraints from given event object.
```php
$expectedEvent = new SomeEvent();

$this->assertThat($expectedEvent, new WasDispatched());
```

This will by default now compare all of the public properties of the dispatched event against the public properties of the expected event. In most cases, this should eliminate the need for manually providing event assertions. 

To provide specific assertions instead, we can use:
```php
$expectedEvent = new SomeEvent();

$this->assertThat($expectedEvent::class, new WasDispatched()->withEventConstraints(
    new PropertyValue('id', new IsIdentical($expectedEvent->id)),
));
```

To customise the way constraints are derived from objects, we can use:
```php
WasDispatched::deriveConstraintsFromObjectUsing(new DeriveConstraintsFromObjectUsingCustomLogic());
```