### PR TITLE
addition: PHPUnit Eloquent model comparator

### DIFF
--- a/src/Laravel/Constraint/Eloquent/ModelComparator.php
+++ b/src/Laravel/Constraint/Eloquent/ModelComparator.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Craftzing\TestBench\Laravel\Constraint\Eloquent;
 
+use AssertionError;
 use Illuminate\Database\Eloquent\Model;
 use SebastianBergmann\Comparator\Comparator;
 use SebastianBergmann\Comparator\ComparisonFailure;
-
-use function assert;
 
 final class ModelComparator extends Comparator
 {
@@ -24,8 +23,8 @@ final class ModelComparator extends Comparator
         bool $canonicalize = false,
         bool $ignoreCase = false,
     ): void {
-        assert($expected instanceof Model);
-        assert($actual instanceof Model);
+        $expected instanceof Model or throw self::notInstanceOfModel('expected', $expected);
+        $actual instanceof Model or throw self::notInstanceOfModel('actual', $actual);
 
         $actual->is($expected) or throw new ComparisonFailure(
             $expected,
@@ -33,6 +32,13 @@ final class ModelComparator extends Comparator
             $expected->getKey(),
             $actual->getKey(),
             'Failed asserting that two Eloquent models are equal.',
+        );
+    }
+
+    private static function notInstanceOfModel(string $argumentName, mixed $value): AssertionError
+    {
+        return new AssertionError(
+            "Argument $argumentName must be an instance of " . Model::class . ', received ' . gettype($value) . '.',
         );
     }
 }

--- a/src/Laravel/Constraint/Eloquent/ModelComparatorTest.php
+++ b/src/Laravel/Constraint/Eloquent/ModelComparatorTest.php
@@ -41,7 +41,7 @@ final class ModelComparatorTest extends TestCase
 
     #[Test]
     #[DataProvider('accepts')]
-    public function itShouldOnlyAcceptExpectedAndActualModels(mixed $expected, mixed $actual, bool $accepted): void
+    public function itOnlyAcceptExpectedAndActualModels(mixed $expected, mixed $actual, bool $accepted): void
     {
         $instance = new ModelComparator();
 
@@ -85,7 +85,7 @@ final class ModelComparatorTest extends TestCase
 
     #[Test]
     #[DataProvider('notEqual')]
-    public function itShouldFailWhenNotEqual(mixed $expected, mixed $actual, string $exceptionFQCN): void
+    public function itFailsWhenNotEqual(mixed $expected, mixed $actual, string $exceptionFQCN): void
     {
         $instance = new ModelComparator();
 
@@ -109,7 +109,7 @@ final class ModelComparatorTest extends TestCase
 
     #[Test]
     #[DataProvider('isEqual')]
-    public function itShouldPassWhenEqual(Model $expected, Model $actual): void
+    public function itPassesWhenEqual(Model $expected, Model $actual): void
     {
         $instance = new ModelComparator();
 


### PR DESCRIPTION
This PR adds a comparator for PHPUnit's `IsEqual` assertion to compare Eloquent models. Instead of comparing entire objects, the comparator relies on Eloquents `Model::is()` method.

To enable the comparator, register it to PHPUnit in the Laravel base test case of your project:
```php
namespace App\Shared\Testing;

use Craftzing\TestBench\Laravel\Constraint\Eloquent\ModelComparator;
use SebastianBergmann\Comparator\Factory;

abstract class TestCase extends IlluminateTestCase
{
    #[Before]
    public function setupConstraints(): void
    {
        Factory::getInstance()->register(new ModelComparator());
    }
}
```