### PR TITLE
fix: `EnumCase` provider should not require at least 2 options

### DIFF
--- a/src/PHPUnit/DataProviders/EnumCase.php
+++ b/src/PHPUnit/DataProviders/EnumCase.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Craftzing\TestBench\PHPUnit\DataProviders;
 
+use LogicException;
 use ReflectionEnum;
 use UnitEnum;
 use ValueError;
 
 use function array_rand;
 use function array_search;
+use function count;
 use function in_array;
 
 /**
@@ -55,6 +57,10 @@ final class EnumCase
      */
     public function differentInstance(): UnitEnum
     {
+        count($this->options) > 1 or throw new LogicException(
+            self::class . ' was configured with a single option and can therefore not return a different instance.',
+        );
+
         $differentOptions = $this->options;
 
         unset($differentOptions[$this->instanceKeyInOptions]);

--- a/src/PHPUnit/DataProviders/EnumCase.php
+++ b/src/PHPUnit/DataProviders/EnumCase.php
@@ -10,7 +10,7 @@ use ValueError;
 
 use function array_rand;
 use function array_search;
-use function count;
+use function in_array;
 
 /**
  * @template TValue of UnitEnum
@@ -33,15 +33,13 @@ final class EnumCase
         }
     }
 
-    /**
-     * @param TValue $instance
-     * @param array<int, TValue> ...$options
-     */
     public function __construct(
+        /* @var TValue */
         public readonly UnitEnum $instance,
+        /* @param array<int, TValue> ...$options */
         UnitEnum ...$options,
     ) {
-        count($options) >= 2 or throw new ValueError('At least 2 options should should be given.');
+        in_array($instance, $options, true) or throw new ValueError('Options should contain the given instance.');
 
         foreach ($options as $option) {
             $option::class === $instance::class or throw new ValueError(

--- a/src/PHPUnit/DataProviders/EnumCase.php
+++ b/src/PHPUnit/DataProviders/EnumCase.php
@@ -9,35 +9,24 @@ use ReflectionEnum;
 use UnitEnum;
 use ValueError;
 
+use function array_filter;
 use function array_rand;
-use function array_search;
 use function count;
 use function in_array;
 
 /**
  * @template TValue of UnitEnum
  */
-final class EnumCase
+final readonly class EnumCase
 {
     /**
      * @var array<int, TValue>
      */
-    private readonly array $options;
-
-    private int|string $instanceKeyInOptions {
-        get {
-            $key = array_search($this->instance, $this->options, true);
-
-            return match ($key) {
-                false => '',
-                default => $key,
-            };
-        }
-    }
+    private array $options;
 
     public function __construct(
         /* @var TValue */
-        public readonly UnitEnum $instance,
+        public UnitEnum $instance,
         /* @param array<int, TValue> ...$options */
         UnitEnum ...$options,
     ) {
@@ -60,10 +49,7 @@ final class EnumCase
         count($this->options) > 1 or throw new LogicException(
             self::class . ' was configured with a single option and can therefore not return a different instance.',
         );
-
-        $differentOptions = $this->options;
-
-        unset($differentOptions[$this->instanceKeyInOptions]);
+        $differentOptions = array_filter($this->options, fn (UnitEnum $option): bool => $option !== $this->instance);
 
         return $differentOptions[array_rand($differentOptions)];
     }

--- a/src/PHPUnit/DataProviders/EnumCaseTest.php
+++ b/src/PHPUnit/DataProviders/EnumCaseTest.php
@@ -9,6 +9,7 @@ use Craftzing\TestBench\PHPUnit\Doubles\Enums\StringBackedEnum;
 use Craftzing\TestBench\PHPUnit\Doubles\Enums\UnitEnum;
 use Faker\Factory;
 use Faker\Generator;
+use Illuminate\Support\Arr;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -48,16 +49,14 @@ final class EnumCaseTest extends TestCase
 
     #[Test]
     #[DataProvider('enumFQCNs')] /** @param class-string<UnitEnumInterface> $enumFQCN */
-    public function itCannotConstructWithoutAtLeastTwoOptions(string $enumFQCN): void
+    public function itCannotConstructWhenInstanceIsNotInOptions(string $enumFQCN): void
     {
-        $cases = $enumFQCN::cases();
+        $options = $enumFQCN::cases();
+        $case = Arr::pull($options, array_rand($options));
 
         $this->expectException(ValueError::class);
 
-        new EnumCase(
-            $this->faker->randomElement($cases),
-            $this->faker->randomElement($cases),
-        );
+        new EnumCase($case, ...$options);
     }
 
     #[Test]
@@ -79,12 +78,24 @@ final class EnumCaseTest extends TestCase
 
     #[Test]
     #[DataProvider('enumFQCNs')] /** @param class-string<UnitEnumInterface> $enumFQCN */
-    public function itCanConstructWithOptions(string $enumFQCN): void
+    public function itCanConstructWithSingleOption(string $enumFQCN): void
     {
-        $cases = $enumFQCN::cases();
-        $case = $cases[array_rand($cases)];
+        $options = $enumFQCN::cases();
+        $case = $options[array_rand($options)];
 
-        $provider = new EnumCase($case, ...$cases);
+        $provider = new EnumCase($case, $case);
+
+        $this->assertSame($case, $provider->instance);
+    }
+
+    #[Test]
+    #[DataProvider('enumFQCNs')] /** @param class-string<UnitEnumInterface> $enumFQCN */
+    public function itCanConstructWithMultipleOptions(string $enumFQCN): void
+    {
+        $options = $enumFQCN::cases();
+        $case = $options[array_rand($options)];
+
+        $provider = new EnumCase($case, ...$options);
 
         $this->assertSame($case, $provider->instance);
     }

--- a/src/PHPUnit/DataProviders/EnumCaseTest.php
+++ b/src/PHPUnit/DataProviders/EnumCaseTest.php
@@ -10,6 +10,7 @@ use Craftzing\TestBench\PHPUnit\Doubles\Enums\UnitEnum;
 use Faker\Factory;
 use Faker\Generator;
 use Illuminate\Support\Arr;
+use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -104,13 +105,26 @@ final class EnumCaseTest extends TestCase
     #[DataProvider('enumFQCNs')] /** @param class-string<UnitEnumInterface> $enumFQCN */
     public function itCanReturnDifferentInstances(string $enumFQCN): void
     {
-        $cases = $enumFQCN::cases();
-        $case = $cases[array_rand($cases)];
+        $options = $enumFQCN::cases();
+        $instance = $options[array_rand($options)];
+        $provider = new EnumCase($instance, ...$options);
 
-        $provider = new EnumCase($case, ...$cases);
+        $differentInstance = $provider->differentInstance();
 
-        $this->assertSame($case, $provider->instance);
-        $this->assertNotEquals($case, $provider->differentInstance());
+        $this->assertNotEquals($instance, $differentInstance);
+    }
+
+    #[Test]
+    #[DataProvider('enumFQCNs')] /** @param class-string<UnitEnumInterface> $enumFQCN */
+    public function itCannotReturnDifferentInstancesWithASingleOption(string $enumFQCN): void
+    {
+        $options = $enumFQCN::cases();
+        $instance = $options[array_rand($options)];
+        $provider = new EnumCase($instance, $instance);
+
+        $this->expectException(LogicException::class);
+
+        $provider->differentInstance();
     }
 
     #[Test]

--- a/src/PHPUnit/DataProviders/EnumCaseTest.php
+++ b/src/PHPUnit/DataProviders/EnumCaseTest.php
@@ -64,17 +64,17 @@ final class EnumCaseTest extends TestCase
     #[DataProvider('enumFQCNs')] /** @param class-string<UnitEnumInterface> $enumFQCN */
     public function itCannotConstructWhenOptionsHaveDifferentTypeComparedToGivenInstance(string $enumFQCN): void
     {
-        $cases = $enumFQCN::cases();
-        $case = $this->faker->randomElement($cases);
+        $options = $enumFQCN::cases();
+        $instance = $this->faker->randomElement($options);
         $differentEnumFQCN = $this->faker->randomElement(array_filter(
             self::ENUM_FQCNS,
-            fn (string $enumFQCN): bool => $enumFQCN !== $case::class,
+            fn (string $enumFQCN): bool => $enumFQCN !== $instance::class,
         ));
-        $differentEnumCase = $this->faker->randomElement($differentEnumFQCN::cases());
+        $differentEnumInstance = $this->faker->randomElement($differentEnumFQCN::cases());
 
         $this->expectException(ValueError::class);
 
-        new EnumCase($case, $differentEnumCase, $differentEnumCase);
+        new EnumCase($instance, $differentEnumInstance, $differentEnumInstance);
     }
 
     #[Test]
@@ -82,11 +82,11 @@ final class EnumCaseTest extends TestCase
     public function itCanConstructWithSingleOption(string $enumFQCN): void
     {
         $options = $enumFQCN::cases();
-        $case = $options[array_rand($options)];
+        $instance = $options[array_rand($options)];
 
-        $provider = new EnumCase($case, $case);
+        $provider = new EnumCase($instance, $instance);
 
-        $this->assertSame($case, $provider->instance);
+        $this->assertSame($instance, $provider->instance);
     }
 
     #[Test]
@@ -94,11 +94,11 @@ final class EnumCaseTest extends TestCase
     public function itCanConstructWithMultipleOptions(string $enumFQCN): void
     {
         $options = $enumFQCN::cases();
-        $case = $options[array_rand($options)];
+        $instance = $options[array_rand($options)];
 
-        $provider = new EnumCase($case, ...$options);
+        $provider = new EnumCase($instance, ...$options);
 
-        $this->assertSame($case, $provider->instance);
+        $this->assertSame($instance, $provider->instance);
     }
 
     #[Test]


### PR DESCRIPTION
In some cases, we dynamically exclude cases from enumeration providers. But when done do dynamically, it is possible for only one case to remain, in which case the provider would throw an error.

This PR changes the behaviour:
- at least 1 option MUST be provided
- the options MUST include the given instance