### PR TITLE
! change: Refactor nested `WasCalled` assertions

### DIFF
--- a/src/Laravel/Constraint/Bus/WasHandledTest.php
+++ b/src/Laravel/Constraint/Bus/WasHandledTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Craftzing\TestBench\Laravel\Constraint\Bus;
 
+use Craftzing\TestBench\PHPUnit\Constraint\Callables\Assertions\WithSameArguments;
 use Craftzing\TestBench\PHPUnit\Constraint\Callables\WasCalled;
 use Craftzing\TestBench\PHPUnit\Constraint\Objects\DeriveConstraintsFromObjectUsingFakes;
 use Craftzing\TestBench\PHPUnit\Constraint\Objects\DeriveConstraintsFromObjectUsingReflection;
@@ -313,18 +314,10 @@ final class WasHandledTest extends TestCase
 
         $this->assertThat($expected, new WasHandled());
 
-        $deriveConstraints->invoke->assert(new WasCalled()->withSame($expected));
-        $deriveConstraints->invoke->assert(
-            new WasCalled()
-                ->never()
-                ->withSame($actual),
-        );
-        $constraint->matches->assert(new WasCalled()->withSame($actual));
-        $constraint->matches->assert(
-            new WasCalled()
-                ->never()
-                ->withSame($expected),
-        );
+        $deriveConstraints->invoke->assert(new WasCalled(new WithSameArguments($expected)));
+        $deriveConstraints->invoke->assert(new WasCalled(new WithSameArguments($expected))->never());
+        $constraint->matches->assert(new WasCalled(new WithSameArguments($expected)));
+        $constraint->matches->assert(new WasCalled(new WithSameArguments($expected))->never());
     }
 
     private function command(array $properties): stdClass

--- a/src/Laravel/Constraint/Bus/WasHandledTest.php
+++ b/src/Laravel/Constraint/Bus/WasHandledTest.php
@@ -315,8 +315,8 @@ final class WasHandledTest extends TestCase
         $this->assertThat($expected, new WasHandled());
 
         $deriveConstraints->invoke->assert(new WasCalled(new WithSameArguments($expected)));
-        $deriveConstraints->invoke->assert(new WasCalled(new WithSameArguments($expected))->never());
-        $constraint->matches->assert(new WasCalled(new WithSameArguments($expected)));
+        $deriveConstraints->invoke->assert(new WasCalled(new WithSameArguments($actual))->never());
+        $constraint->matches->assert(new WasCalled(new WithSameArguments($actual)));
         $constraint->matches->assert(new WasCalled(new WithSameArguments($expected))->never());
     }
 

--- a/src/PHPUnit/Constraint/Callables/Assertions/WithEqualArguments.php
+++ b/src/PHPUnit/Constraint/Callables/Assertions/WithEqualArguments.php
@@ -20,10 +20,21 @@ final readonly class WithEqualArguments
 
     public function __invoke(mixed ...$actual): void
     {
-        Assert::assertCount(count($this->expected), $actual);
+        Assert::assertCount(
+            count($this->expected),
+            $actual,
+            'Callable was invoked with a different amount of arguments.',
+        );
 
         foreach ($actual as $key => $value) {
-            Assert::assertEquals($this->expected[$key], $value);
+            // @mago-expect analyzer:invalid-operand
+            $argumentNumber = $key + 1;
+
+            Assert::assertEquals(
+                $this->expected[$key],
+                $value,
+                "Argument #{$argumentNumber} passed to callable does not match expected value.",
+            );
         }
     }
 }

--- a/src/PHPUnit/Constraint/Callables/Assertions/WithEqualArguments.php
+++ b/src/PHPUnit/Constraint/Callables/Assertions/WithEqualArguments.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Craftzing\TestBench\PHPUnit\Constraint\Callables\Assertions;
+
+use PHPUnit\Framework\Assert;
+
+use function count;
+
+final readonly class WithEqualArguments
+{
+    /** @var array */
+    private array $expected;
+
+    public function __construct(mixed ...$expected)
+    {
+        $this->expected = $expected;
+    }
+
+    public function __invoke(mixed ...$actual): void
+    {
+        Assert::assertCount(count($this->expected), $actual);
+
+        foreach ($actual as $key => $value) {
+            Assert::assertEquals($this->expected[$key], $value);
+        }
+    }
+}

--- a/src/PHPUnit/Constraint/Callables/Assertions/WithEqualArgumentsTest.php
+++ b/src/PHPUnit/Constraint/Callables/Assertions/WithEqualArgumentsTest.php
@@ -20,18 +20,20 @@ final class WithEqualArgumentsTest extends TestCase
         $instance = new WithEqualArguments('first', 'last');
 
         $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('was invoked with a different amount of arguments');
 
         $instance->__invoke(...$actual);
     }
 
     #[Test]
-    #[TestWith(['first different', 'last'])]
-    #[TestWith(['first', 'last different'])]
-    public function itFailsWhenInvokedWithDifferentArguments(string ...$actual): void
+    #[TestWith([1, 'first different', 'last'])]
+    #[TestWith([2, 'first', 'last different'])]
+    public function itFailsWhenInvokedWithDifferentArguments(int $argument, string ...$actual): void
     {
         $instance = new WithEqualArguments('first', 'last');
 
         $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Argument #{$argument} passed to callable does not match expected value");
 
         $instance->__invoke(...$actual);
     }
@@ -42,6 +44,7 @@ final class WithEqualArgumentsTest extends TestCase
         $instance = new WithEqualArguments('first', 'last');
 
         $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Argument #1 passed to callable does not match expected value');
 
         $instance->__invoke('last', 'first');
     }

--- a/src/PHPUnit/Constraint/Callables/Assertions/WithEqualArgumentsTest.php
+++ b/src/PHPUnit/Constraint/Callables/Assertions/WithEqualArgumentsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Craftzing\TestBench\PHPUnit\Constraint\Callables\Assertions;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class WithEqualArgumentsTest extends TestCase
+{
+    #[Test]
+    #[TestWith(['first'], 'Too few arguments')]
+    #[TestWith(['first', 'second', 'last'], 'Too many arguments')]
+    public function itFailsWhenInvokedWithDifferentAmountOfArguments(string ...$actual): void
+    {
+        $instance = new WithEqualArguments('first', 'last');
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $instance->__invoke(...$actual);
+    }
+
+    #[Test]
+    #[TestWith(['first different', 'last'])]
+    #[TestWith(['first', 'last different'])]
+    public function itFailsWhenInvokedWithDifferentArguments(string ...$actual): void
+    {
+        $instance = new WithEqualArguments('first', 'last');
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $instance->__invoke(...$actual);
+    }
+
+    #[Test]
+    public function itFailsWhenInvokedWithArgumentsInDifferentOrder(): void
+    {
+        $instance = new WithEqualArguments('first', 'last');
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $instance->__invoke('last', 'first');
+    }
+
+    #[Test]
+    #[TestWith(['first', 'second', 'last'], 'Scalar arguments')]
+    #[TestWith([new stdClass()], 'Object arguments')]
+    public function itPassesWhenInvokedWithSameArguments(mixed ...$actual): void
+    {
+        $instance = new WithEqualArguments(...$actual);
+
+        $instance->__invoke(...$actual);
+    }
+
+    #[Test]
+    public function itPassesWhenInvokedWithEqualArguments(): void
+    {
+        $instance = new WithEqualArguments(new stdClass());
+
+        $instance->__invoke(new stdClass());
+    }
+}

--- a/src/PHPUnit/Constraint/Callables/Assertions/WithSameArguments.php
+++ b/src/PHPUnit/Constraint/Callables/Assertions/WithSameArguments.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Craftzing\TestBench\PHPUnit\Constraint\Callables\Assertions;
+
+use PHPUnit\Framework\Assert;
+
+use function count;
+
+final readonly class WithSameArguments
+{
+    /** @var array */
+    private array $expected;
+
+    public function __construct(mixed ...$expected)
+    {
+        $this->expected = $expected;
+    }
+
+    public function __invoke(mixed ...$actual): void
+    {
+        Assert::assertCount(count($this->expected), $actual);
+
+        foreach ($actual as $key => $value) {
+            Assert::assertSame($this->expected[$key], $value);
+        }
+    }
+}

--- a/src/PHPUnit/Constraint/Callables/Assertions/WithSameArguments.php
+++ b/src/PHPUnit/Constraint/Callables/Assertions/WithSameArguments.php
@@ -20,10 +20,21 @@ final readonly class WithSameArguments
 
     public function __invoke(mixed ...$actual): void
     {
-        Assert::assertCount(count($this->expected), $actual);
+        Assert::assertCount(
+            count($this->expected),
+            $actual,
+            'Callable was invoked with a different amount of arguments.',
+        );
 
         foreach ($actual as $key => $value) {
-            Assert::assertSame($this->expected[$key], $value);
+            // @mago-expect analyzer:invalid-operand
+            $argumentNumber = $key + 1;
+
+            Assert::assertSame(
+                $this->expected[$key],
+                $value,
+                "Argument #{$argumentNumber} passed to callable does not match expected value.",
+            );
         }
     }
 }

--- a/src/PHPUnit/Constraint/Callables/Assertions/WithSameArgumentsTest.php
+++ b/src/PHPUnit/Constraint/Callables/Assertions/WithSameArgumentsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Craftzing\TestBench\PHPUnit\Constraint\Callables\Assertions;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class WithSameArgumentsTest extends TestCase
+{
+    #[Test]
+    #[TestWith(['first'], 'Too few arguments')]
+    #[TestWith(['first', 'second', 'last'], 'Too many arguments')]
+    public function itFailsWhenInvokedWithDifferentAmountOfArguments(string ...$actual): void
+    {
+        $instance = new WithSameArguments('first', 'last');
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $instance->__invoke(...$actual);
+    }
+
+    #[Test]
+    #[TestWith(['first different', 'last'])]
+    #[TestWith(['first', 'last different'])]
+    public function itFailsWhenInvokedWithDifferentArguments(string ...$actual): void
+    {
+        $instance = new WithSameArguments('first', 'last');
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $instance->__invoke(...$actual);
+    }
+
+    #[Test]
+    public function itFailsWhenInvokedWithArgumentsInDifferentOrder(): void
+    {
+        $instance = new WithSameArguments('first', 'last');
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $instance->__invoke('last', 'first');
+    }
+
+    #[Test]
+    public function itFailsWhenInvokedWithNonIdenticalArguments(): void
+    {
+        $instance = new WithSameArguments(new stdClass());
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $instance->__invoke(new stdClass());
+    }
+
+    #[Test]
+    #[TestWith(['first', 'second', 'last'], 'Scalar arguments')]
+    #[TestWith([new stdClass()], 'Object arguments')]
+    public function itPassesWhenInvokedWithSameArguments(mixed ...$actual): void
+    {
+        $instance = new WithSameArguments(...$actual);
+
+        $instance->__invoke(...$actual);
+    }
+}

--- a/src/PHPUnit/Constraint/Callables/Assertions/WithSameArgumentsTest.php
+++ b/src/PHPUnit/Constraint/Callables/Assertions/WithSameArgumentsTest.php
@@ -20,18 +20,20 @@ final class WithSameArgumentsTest extends TestCase
         $instance = new WithSameArguments('first', 'last');
 
         $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('was invoked with a different amount of arguments');
 
         $instance->__invoke(...$actual);
     }
 
     #[Test]
-    #[TestWith(['first different', 'last'])]
-    #[TestWith(['first', 'last different'])]
-    public function itFailsWhenInvokedWithDifferentArguments(string ...$actual): void
+    #[TestWith([1, 'first different', 'last'])]
+    #[TestWith([2, 'first', 'last different'])]
+    public function itFailsWhenInvokedWithDifferentArguments(int $argument, string ...$actual): void
     {
         $instance = new WithSameArguments('first', 'last');
 
         $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Argument #{$argument} passed to callable does not match expected value");
 
         $instance->__invoke(...$actual);
     }
@@ -42,6 +44,7 @@ final class WithSameArgumentsTest extends TestCase
         $instance = new WithSameArguments('first', 'last');
 
         $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Argument #1 passed to callable does not match expected value');
 
         $instance->__invoke('last', 'first');
     }
@@ -52,6 +55,7 @@ final class WithSameArgumentsTest extends TestCase
         $instance = new WithSameArguments(new stdClass());
 
         $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Argument #1 passed to callable does not match expected value');
 
         $instance->__invoke(new stdClass());
     }

--- a/src/PHPUnit/Constraint/Callables/WasCalled.php
+++ b/src/PHPUnit/Constraint/Callables/WasCalled.php
@@ -4,38 +4,31 @@ declare(strict_types=1);
 
 namespace Craftzing\TestBench\PHPUnit\Constraint\Callables;
 
-use Closure;
 use Craftzing\TestBench\PHPUnit\Constraint\ProvidesAdditionalFailureDescription;
 use Craftzing\TestBench\PHPUnit\Constraint\Quantable;
 use Craftzing\TestBench\PHPUnit\Doubles\CallableInvocation;
 use Craftzing\TestBench\PHPUnit\Doubles\SpyCallable;
 use InvalidArgumentException;
 use Override;
-use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\ExpectationFailedException;
 
 use function array_filter;
 use function count;
+use function is_callable;
 
 final class WasCalled extends Constraint implements Quantable
 {
     use ProvidesAdditionalFailureDescription;
 
+    /** @var callable|null */
+    public readonly mixed $assertInvocation;
+
     public function __construct(
-        public readonly ?Closure $assertInvocation = null,
+        ?callable $assertInvocation = null,
         public readonly ?int $times = null,
-    ) {}
-
-    public function withSame(mixed ...$expected): self
-    {
-        return new self(static function (mixed ...$actual) use ($expected): void {
-            Assert::assertCount(count($expected), $actual);
-
-            foreach ($actual as $key => $value) {
-                Assert::assertSame($expected[$key], $value);
-            }
-        }, $this->times);
+    ) {
+        $this->assertInvocation = $assertInvocation;
     }
 
     public function times(int $count): self
@@ -72,9 +65,12 @@ final class WasCalled extends Constraint implements Quantable
 
     private function matchesInvocationAssertions(CallableInvocation $invocation): bool
     {
+        if (!is_callable($this->assertInvocation)) {
+            return false;
+        }
+
         try {
-            // @mago-expect analyzer:invalid-method-access
-            $this->assertInvocation?->__invoke(...$invocation->arguments);
+            ( $this->assertInvocation )(...$invocation->arguments);
         } catch (ExpectationFailedException $expectationFailed) {
             $this->additionalFailureDescriptions[] = $expectationFailed->getMessage();
 

--- a/src/PHPUnit/Constraint/Callables/WasCalled.php
+++ b/src/PHPUnit/Constraint/Callables/WasCalled.php
@@ -22,28 +22,28 @@ final class WasCalled extends Constraint implements Quantable
     use ProvidesAdditionalFailureDescription;
 
     /** @var callable|null */
-    public readonly mixed $assertInvocation;
+    public readonly mixed $withArguments;
 
     public function __construct(
-        ?callable $assertInvocation = null,
+        ?callable $withArguments = null,
         public readonly ?int $times = null,
     ) {
-        $this->assertInvocation = $assertInvocation;
+        $this->withArguments = $withArguments;
     }
 
     public function times(int $count): self
     {
-        return new self($this->assertInvocation, $count);
+        return new self($this->withArguments, $count);
     }
 
     public function never(): self
     {
-        return new self($this->assertInvocation, 0);
+        return new self($this->withArguments, 0);
     }
 
     public function once(): self
     {
-        return new self($this->assertInvocation, 1);
+        return new self($this->withArguments, 1);
     }
 
     #[Override]
@@ -55,7 +55,7 @@ final class WasCalled extends Constraint implements Quantable
             );
         }
 
-        $matchingInvocations = array_filter($other->invocations, $this->matchesInvocationAssertions(...));
+        $matchingInvocations = array_filter($other->invocations, $this->wasInvokedWithExpectedArguments(...));
 
         return match ($this->times) {
             null => $matchingInvocations !== [],
@@ -63,14 +63,14 @@ final class WasCalled extends Constraint implements Quantable
         };
     }
 
-    private function matchesInvocationAssertions(CallableInvocation $invocation): bool
+    private function wasInvokedWithExpectedArguments(CallableInvocation $invocation): bool
     {
-        if (!is_callable($this->assertInvocation)) {
-            return false;
+        if (!is_callable($this->withArguments)) {
+            return true;
         }
 
         try {
-            ( $this->assertInvocation )(...$invocation->arguments);
+            ( $this->withArguments )(...$invocation->arguments);
         } catch (ExpectationFailedException $expectationFailed) {
             $this->additionalFailureDescriptions[] = $expectationFailed->getMessage();
 
@@ -88,8 +88,8 @@ final class WasCalled extends Constraint implements Quantable
             $message .= " {$this->times} time(s)";
         }
 
-        if ($this->assertInvocation !== null) {
-            $message .= ' with given invocation assertions';
+        if ($this->withArguments !== null) {
+            $message .= ' with given arguments';
         }
 
         return $message;

--- a/src/PHPUnit/Constraint/Callables/WasCalled.php
+++ b/src/PHPUnit/Constraint/Callables/WasCalled.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 use function array_filter;
 use function count;
 use function is_callable;
+use function spl_object_id;
 
 final class WasCalled extends Constraint implements Quantable
 {
@@ -78,6 +79,22 @@ final class WasCalled extends Constraint implements Quantable
         }
 
         return true;
+    }
+
+    protected function failureDescription(mixed $other): string
+    {
+        if (!$other instanceof SpyCallable) {
+            return parent::failureDescription($other);
+        }
+
+        $message = $other::class . '#' . spl_object_id($other);
+
+        if ($this->times !== null) {
+            $totalInvocations = count($other->invocations);
+            $message .= " (with {$totalInvocations} total invocations)";
+        }
+
+        return "{$message} {$this->toString()}";
     }
 
     public function toString(): string

--- a/src/PHPUnit/Constraint/Callables/WasCalledTest.php
+++ b/src/PHPUnit/Constraint/Callables/WasCalledTest.php
@@ -22,7 +22,7 @@ final class WasCalledTest extends TestCase
     {
         $instance = new WasCalled();
 
-        $this->assertNull($instance->assertInvocation);
+        $this->assertNull($instance->withArguments);
         $this->assertNull($instance->times);
     }
 
@@ -33,7 +33,7 @@ final class WasCalledTest extends TestCase
 
         $instance = new WasCalled($assertInvocation);
 
-        $this->assertSame($assertInvocation, $instance->assertInvocation);
+        $this->assertSame($assertInvocation, $instance->withArguments);
         $this->assertNull($instance->times);
     }
 
@@ -47,9 +47,9 @@ final class WasCalledTest extends TestCase
         $quantisedInstance = $quantise($instance);
 
         $this->assertNull($instance->times);
-        $this->assertSame($assertInvocation, $instance->assertInvocation);
+        $this->assertSame($assertInvocation, $instance->withArguments);
         $this->assertSame($quantise->times, $quantisedInstance->times);
-        $this->assertSame($assertInvocation, $quantisedInstance->assertInvocation);
+        $this->assertSame($assertInvocation, $quantisedInstance->withArguments);
     }
 
     #[Test]
@@ -87,7 +87,7 @@ final class WasCalledTest extends TestCase
         $callable('last', 'first');
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('was called with given invocation assertions.');
+        $this->expectExceptionMessage('was called with given arguments.');
 
         $this->assertThat($callable, new WasCalled(function (string $first, string $last): void {
             $this->assertSame('first', $first);
@@ -140,7 +140,7 @@ final class WasCalledTest extends TestCase
         $quantise->applyTo(static fn() => $callable('first', 'last'));
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage("was called {$quantise->expected} time(s) with given invocation assertions.");
+        $this->expectExceptionMessage("was called {$quantise->expected} time(s) with given arguments.");
 
         $this->assertThat(
             $callable,

--- a/src/PHPUnit/DataProviders/QuantableConstraintTest.php
+++ b/src/PHPUnit/DataProviders/QuantableConstraintTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Craftzing\TestBench\PHPUnit\DataProviders;
 
+use Craftzing\TestBench\PHPUnit\Constraint\Callables\Assertions\WithSameArguments;
 use Craftzing\TestBench\PHPUnit\Constraint\Callables\WasCalled;
 use Craftzing\TestBench\PHPUnit\Constraint\Quantable;
 use Craftzing\TestBench\PHPUnit\Doubles\SpyCallable;
@@ -63,11 +64,7 @@ final class QuantableConstraintTest extends TestCase
 
         $instance($constraint);
 
-        $constraint->spy->assert(
-            new WasCalled()
-                ->withSame($instance->method, $instance->times)
-                ->once(),
-        );
+        $constraint->spy->assert(new WasCalled(new WithSameArguments($constraint))->once());
     }
 
     #[Test]

--- a/src/PHPUnit/DataProviders/QuantableConstraintTest.php
+++ b/src/PHPUnit/DataProviders/QuantableConstraintTest.php
@@ -64,7 +64,7 @@ final class QuantableConstraintTest extends TestCase
 
         $instance($constraint);
 
-        $constraint->spy->assert(new WasCalled(new WithSameArguments($constraint))->once());
+        $constraint->spy->assert(new WasCalled(new WithSameArguments($instance->method, $instance->times))->once());
     }
 
     #[Test]


### PR DESCRIPTION
> [!WARNING]
> This PR contains a breaking change. See upgrade guide for more details.

# Context

In an attempt not to overload the `WasCalled` constraint with more methods, this PR aims to simplify its API by abstracting the `withSame()` method onto a standalone assertion `Craftzing\TestBench\PHPUnit\Constraint\Callables\Assertions\WithSameArguments`. This allows us to add more `WasCalled` assertions like `Craftzing\TestBench\PHPUnit\Constraint\Callables\Assertions\WithEqualArguments` (as introduced in this PR.

# Failure output improvements

Previously, whenever a `WasCalled` assertion failed, PHPUnit would export the full object in the failure description. E.g.:
```
There were 4 failures:

1) Craftzing\TestBench\PHPUnit\Constraint\Callables\WasCalledTest::itFailsWhenNotCalled
Failed asserting that Craftzing\TestBench\PHPUnit\Doubles\SpyCallable Object #165 (
    'invocations' => Array &0 [],
    'return' => null,
) was called.

/code/src/PHPUnit/Constraint/Callables/WasCalledTest.php:69

2) Craftzing\TestBench\PHPUnit\Constraint\Callables\WasCalledTest::itFailsWhenNotCalledWithExpectedArguments
Failed asserting that Craftzing\TestBench\PHPUnit\Doubles\SpyCallable Object #2431 (
    'invocations' => Array &0 [
        0 => Craftzing\TestBench\PHPUnit\Doubles\CallableInvocation Object #2533 (
            'arguments' => Array &1 [
                0 => 'last',
                1 => 'first',
            ],
        ),
    ],
    'return' => null,
) was called with given arguments.

* Failed asserting that two strings are identical.

/code/src/PHPUnit/Constraint/Callables/WasCalledTest.php:92

3) Craftzing\TestBench\PHPUnit\Constraint\Callables\WasCalledTest::itFailsWhenNotCalledExpectedTimesWithExpectedArguments with data set "Too few times" (Craftzing\TestBench\PHPUnit\DataProviders\QuantableConstraint Object (...))
Failed asserting that Craftzing\TestBench\PHPUnit\Doubles\SpyCallable Object #2254 (
    'invocations' => Array &0 [
        0 => Craftzing\TestBench\PHPUnit\Doubles\CallableInvocation Object #2263 (
            'arguments' => Array &1 [
                0 => 'first',
                1 => 'last',
            ],
        ),
        1 => Craftzing\TestBench\PHPUnit\Doubles\CallableInvocation Object #2278 (
            'arguments' => Array &2 [
                0 => 'first',
                1 => 'last',
            ],
        ),
    ],
    'return' => null,
) was called 1 time(s) with given arguments.

/code/src/PHPUnit/Constraint/Callables/WasCalledTest.php:145

4) Craftzing\TestBench\PHPUnit\Constraint\Callables\WasCalledTest::itFailsWhenNotCalledExpectedTimesWithExpectedArguments with data set "Too many times" (Craftzing\TestBench\PHPUnit\DataProviders\QuantableConstraint Object (...))
Failed asserting that Craftzing\TestBench\PHPUnit\Doubles\SpyCallable Object #2543 (
    'invocations' => Array &0 [
        0 => Craftzing\TestBench\PHPUnit\Doubles\CallableInvocation Object #2257 (
            'arguments' => Array &1 [
                0 => 'first',
                1 => 'last',
            ],
        ),
        1 => Craftzing\TestBench\PHPUnit\Doubles\CallableInvocation Object #2431 (
            'arguments' => Array &2 [
                0 => 'first',
                1 => 'last',
            ],
        ),
    ],
    'return' => null,
) was called 3 time(s) with given arguments.

/code/src/PHPUnit/Constraint/Callables/WasCalledTest.php:145
```

Even with really simply arguments like short strings, this output was already very verbose. And it only gets worse when passing objects as arguments.

Therefore, this PR proposes to simplify the object representation to:
- only include the FQCN and object ID
- include the total amount of invocations (when asserting that a callable was called a specific amount of times)

```
There were 4 failures:

1) Craftzing\TestBench\PHPUnit\Constraint\Callables\WasCalledTest::itFailsWhenNotCalled
Failed asserting that Craftzing\TestBench\PHPUnit\Doubles\SpyCallable#165 was called.

/code/src/PHPUnit/Constraint/Callables/WasCalledTest.php:69

2) Craftzing\TestBench\PHPUnit\Constraint\Callables\WasCalledTest::itFailsWhenNotCalledWithExpectedArguments
Failed asserting that Craftzing\TestBench\PHPUnit\Doubles\SpyCallable#2431 was called with given arguments.

* Failed asserting that two strings are identical.

/code/src/PHPUnit/Constraint/Callables/WasCalledTest.php:92

3) Craftzing\TestBench\PHPUnit\Constraint\Callables\WasCalledTest::itFailsWhenNotCalledExpectedTimesWithExpectedArguments with data set "Too few times" (Craftzing\TestBench\PHPUnit\DataProviders\QuantableConstraint Object (...))
Failed asserting that Craftzing\TestBench\PHPUnit\Doubles\SpyCallable#2254 (with 2 total invocations) was called 1 time(s) with given arguments.

/code/src/PHPUnit/Constraint/Callables/WasCalledTest.php:145

4) Craftzing\TestBench\PHPUnit\Constraint\Callables\WasCalledTest::itFailsWhenNotCalledExpectedTimesWithExpectedArguments with data set "Too many times" (Craftzing\TestBench\PHPUnit\DataProviders\QuantableConstraint Object (...))
Failed asserting that Craftzing\TestBench\PHPUnit\Doubles\SpyCallable#2274 (with 2 total invocations) was called 3 time(s) with given arguments.

/code/src/PHPUnit/Constraint/Callables/WasCalledTest.php:145
```

# Upgrade guide

`Craftzing\TestBench\PHPUnit\Constraint\Callables\WasCalled::withSame()` is no longer available. You can replace it by providing the new `Craftzing\TestBench\PHPUnit\Constraint\Callables\Assertions\WithSameArguments` assertion as first argument to `WasCalled`:
```php
use Craftzing\TestBench\PHPUnit\Constraint\Callables\WasCalled;
use Craftzing\TestBench\PHPUnit\Constraint\Callables\Assertions\WithSameArguments;

$this->assertThat($callable, new WasCalles(new WithSameArguments(...$arguments)));
```

You may now also use loose comparison:
```php
use Craftzing\TestBench\PHPUnit\Constraint\Callables\WasCalled;
use Craftzing\TestBench\PHPUnit\Constraint\Callables\Assertions\WithEqualArguments;

$this->assertThat($callable, new WasCalles(new WithEqualArguments(...$arguments)));
```